### PR TITLE
Randomize suffix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.idea
 /.composer-src
+/vendor

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ A plugin for Composer package manager making it working a bit better within Word
 
 For now, the only purpose of the project is to fix the following error when there is a WordPress plugin built with an obsolete pre-PSR-4 Composer version:
 ```
-Fatal error: Call to undefined method Composer\Autoload\ClassLoader::setPsr4() 
+Fatal error: Call to undefined method Composer\Autoload\ClassLoader::setPsr4()
 in <...>/wp-content/plugins/<plugin-name>/vendor/composer/autoload_real.php on line 33
 ```
 
-The plugin patches Composer's autoload scripts every time they are changed due to `composer install`, `composer update` or other Composer actions. 
+The plugin patches Composer's autoload scripts every time they are changed due to `composer install`, `composer update` or other Composer actions.
 
 <a href="https://github.com/composer/composer/issues/3852">More info and discussion</a>
 
@@ -20,3 +20,8 @@ Just require the package in your project's `composer.json`:
 }
 ```
 
+You can set the class loader suffix in `composer.json`:
+```json
+"classloader-suffix": "MySuffix"
+```
+If you don't do that, a random suffix will be generated.


### PR DESCRIPTION
This PR adds a new config option `classloader-suffix` to explicitly set the suffix and creates a random suffix if the option is not set. IMHO this is a more general solution, as PSR4 support is not the only thing newer Composer versions have added.