### PR TITLE
Support Composer 2.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea
 /.composer-src
 /vendor
+composer.lock

--- a/ComposerForWordpress.php
+++ b/ComposerForWordpress.php
@@ -15,6 +15,14 @@ class ComposerForWordpress implements PluginInterface, EventSubscriberInterface
     {
     }
 
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+    }
+
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+    }
+
     public static function getSubscribedEvents()
     {
         return array(

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "class": "Dangoodman\\ComposerForWordpress\\ComposerForWordpress"
     },
     "require": {
-        "composer-plugin-api": "^1.0"
+        "composer-plugin-api": "^1.0 || ^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Composer 2.x has a new plugin API version. Since the changes are minimal, this PR supports both versions.